### PR TITLE
feat: GET /me/channels/:channelId/episodes API を実装

### DIFF
--- a/http/episodes.http
+++ b/http/episodes.http
@@ -1,0 +1,20 @@
+@baseUrl = http://localhost:8081/api/v1
+
+# トークン生成: make token
+@token = YOUR_TOKEN_HERE
+
+### 自分のチャンネルのエピソード一覧取得
+GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE/episodes
+Authorization: Bearer {{token}}
+
+### 自分のチャンネルのエピソード一覧取得（公開済みのみ）
+GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE/episodes?status=published
+Authorization: Bearer {{token}}
+
+### 自分のチャンネルのエピソード一覧取得（下書きのみ）
+GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE/episodes?status=draft
+Authorization: Bearer {{token}}
+
+### 自分のチャンネルのエピソード一覧取得（ページネーション）
+GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE/episodes?limit=10&offset=0
+Authorization: Bearer {{token}}

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -17,6 +17,7 @@ type Container struct {
 	AuthHandler     *handler.AuthHandler
 	ChannelHandler  *handler.ChannelHandler
 	CategoryHandler *handler.CategoryHandler
+	EpisodeHandler  *handler.EpisodeHandler
 	TokenManager    jwt.TokenManager
 }
 
@@ -34,24 +35,28 @@ func NewContainer(db *gorm.DB, cfg *config.Config) *Container {
 	imageRepo := repository.NewImageRepository(db)
 	channelRepo := repository.NewChannelRepository(db)
 	categoryRepo := repository.NewCategoryRepository(db)
+	episodeRepo := repository.NewEpisodeRepository(db)
 
 	// Service 層
 	voiceService := service.NewVoiceService(voiceRepo)
 	authService := service.NewAuthService(userRepo, credentialRepo, oauthAccountRepo, imageRepo, passwordHasher)
 	channelService := service.NewChannelService(channelRepo, categoryRepo, imageRepo, voiceRepo)
 	categoryService := service.NewCategoryService(categoryRepo)
+	episodeService := service.NewEpisodeService(episodeRepo, channelRepo)
 
 	// Handler 層
 	voiceHandler := handler.NewVoiceHandler(voiceService)
 	authHandler := handler.NewAuthHandler(authService, tokenManager)
 	channelHandler := handler.NewChannelHandler(channelService)
 	categoryHandler := handler.NewCategoryHandler(categoryService)
+	episodeHandler := handler.NewEpisodeHandler(episodeService)
 
 	return &Container{
 		VoiceHandler:    voiceHandler,
 		AuthHandler:     authHandler,
 		ChannelHandler:  channelHandler,
 		CategoryHandler: categoryHandler,
+		EpisodeHandler:  episodeHandler,
 		TokenManager:    tokenManager,
 	}
 }

--- a/internal/dto/request/episode.go
+++ b/internal/dto/request/episode.go
@@ -1,0 +1,7 @@
+package request
+
+// 自分のチャンネルのエピソード一覧取得リクエスト
+type ListMyChannelEpisodesRequest struct {
+	PaginationRequest
+	Status *string `form:"status" binding:"omitempty,oneof=published draft"`
+}

--- a/internal/dto/response/audio.go
+++ b/internal/dto/response/audio.go
@@ -1,0 +1,10 @@
+package response
+
+import "github.com/google/uuid"
+
+// 音声ファイル情報のレスポンス
+type AudioResponse struct {
+	ID         uuid.UUID `json:"id" validate:"required"`
+	URL        string    `json:"url" validate:"required"`
+	DurationMs int       `json:"durationMs" validate:"required"`
+}

--- a/internal/dto/response/episode.go
+++ b/internal/dto/response/episode.go
@@ -1,0 +1,25 @@
+package response
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// エピソード情報のレスポンス
+type EpisodeResponse struct {
+	ID           uuid.UUID      `json:"id" validate:"required"`
+	Title        string         `json:"title" validate:"required"`
+	Description  *string        `json:"description"`
+	ScriptPrompt string         `json:"scriptPrompt" validate:"required"`
+	FullAudio    *AudioResponse `json:"fullAudio"`
+	PublishedAt  *time.Time     `json:"publishedAt"`
+	CreatedAt    time.Time      `json:"createdAt" validate:"required"`
+	UpdatedAt    time.Time      `json:"updatedAt" validate:"required"`
+}
+
+// エピソード一覧（ページネーション付き）のレスポンス
+type EpisodeListWithPaginationResponse struct {
+	Data       []EpisodeResponse  `json:"data" validate:"required"`
+	Pagination PaginationResponse `json:"pagination" validate:"required"`
+}

--- a/internal/handler/episode_test.go
+++ b/internal/handler/episode_test.go
@@ -1,0 +1,205 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/siropaca/anycast-backend/internal/apperror"
+	"github.com/siropaca/anycast-backend/internal/dto/response"
+	"github.com/siropaca/anycast-backend/internal/middleware"
+	"github.com/siropaca/anycast-backend/internal/repository"
+)
+
+// EpisodeService のモック
+type mockEpisodeService struct {
+	mock.Mock
+}
+
+func (m *mockEpisodeService) ListMyChannelEpisodes(ctx context.Context, userID, channelID string, filter repository.EpisodeFilter) (*response.EpisodeListWithPaginationResponse, error) {
+	args := m.Called(ctx, userID, channelID, filter)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*response.EpisodeListWithPaginationResponse), args.Error(1)
+}
+
+// テスト用のルーターをセットアップする
+func setupEpisodeRouter(h *EpisodeHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/me/channels/:channelId/episodes", h.ListMyChannelEpisodes)
+	return r
+}
+
+// 認証済みルーターをセットアップする
+func setupAuthenticatedEpisodeRouter(h *EpisodeHandler, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.UserIDKey), userID)
+		c.Next()
+	})
+	r.GET("/me/channels/:channelId/episodes", h.ListMyChannelEpisodes)
+	return r
+}
+
+// テスト用のエピソードレスポンスを生成する
+func createTestEpisodeResponse() response.EpisodeResponse {
+	now := time.Now()
+	description := "Test Description"
+	return response.EpisodeResponse{
+		ID:           uuid.New(),
+		Title:        "Test Episode",
+		Description:  &description,
+		ScriptPrompt: "Test Script Prompt",
+		FullAudio: &response.AudioResponse{
+			ID:         uuid.New(),
+			URL:        "https://example.com/audio.mp3",
+			DurationMs: 180000,
+		},
+		PublishedAt: &now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+}
+
+func TestEpisodeHandler_ListMyChannelEpisodes(t *testing.T) {
+	userID := uuid.New().String()
+	channelID := uuid.New().String()
+
+	t.Run("エピソード一覧を取得できる", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		episodes := []response.EpisodeResponse{createTestEpisodeResponse()}
+		result := &response.EpisodeListWithPaginationResponse{
+			Data:       episodes,
+			Pagination: response.PaginationResponse{Total: 1, Limit: 20, Offset: 0},
+		}
+		mockSvc.On("ListMyChannelEpisodes", mock.Anything, userID, channelID, mock.AnythingOfType("repository.EpisodeFilter")).Return(result, nil)
+
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupAuthenticatedEpisodeRouter(handler, userID)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp response.EpisodeListWithPaginationResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Len(t, resp.Data, 1)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("空のエピソード一覧を取得できる", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		result := &response.EpisodeListWithPaginationResponse{
+			Data:       []response.EpisodeResponse{},
+			Pagination: response.PaginationResponse{Total: 0, Limit: 20, Offset: 0},
+		}
+		mockSvc.On("ListMyChannelEpisodes", mock.Anything, userID, channelID, mock.AnythingOfType("repository.EpisodeFilter")).Return(result, nil)
+
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupAuthenticatedEpisodeRouter(handler, userID)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp response.EpisodeListWithPaginationResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Empty(t, resp.Data)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("クエリパラメータでフィルタできる", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		result := &response.EpisodeListWithPaginationResponse{
+			Data:       []response.EpisodeResponse{},
+			Pagination: response.PaginationResponse{Total: 0, Limit: 10, Offset: 5},
+		}
+		mockSvc.On("ListMyChannelEpisodes", mock.Anything, userID, channelID, mock.MatchedBy(func(f repository.EpisodeFilter) bool {
+			return f.Limit == 10 && f.Offset == 5 && *f.Status == "published"
+		})).Return(result, nil)
+
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupAuthenticatedEpisodeRouter(handler, userID)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes?status=published&limit=10&offset=5", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("チャンネルが見つからない場合は 404 を返す", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		mockSvc.On("ListMyChannelEpisodes", mock.Anything, userID, channelID, mock.AnythingOfType("repository.EpisodeFilter")).Return(nil, apperror.ErrNotFound.WithMessage("Channel not found"))
+
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupAuthenticatedEpisodeRouter(handler, userID)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("権限がない場合は 403 を返す", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		mockSvc.On("ListMyChannelEpisodes", mock.Anything, userID, channelID, mock.AnythingOfType("repository.EpisodeFilter")).Return(nil, apperror.ErrForbidden.WithMessage("You do not have permission"))
+
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupAuthenticatedEpisodeRouter(handler, userID)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("サービスがエラーを返すとエラーレスポンスを返す", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		mockSvc.On("ListMyChannelEpisodes", mock.Anything, userID, channelID, mock.AnythingOfType("repository.EpisodeFilter")).Return(nil, apperror.ErrInternal)
+
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupAuthenticatedEpisodeRouter(handler, userID)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("未認証の場合は 401 を返す", func(t *testing.T) {
+		mockSvc := new(mockEpisodeService)
+		handler := NewEpisodeHandler(mockSvc)
+		router := setupEpisodeRouter(handler)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/me/channels/"+channelID+"/episodes", http.NoBody)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/internal/model/audio.go
+++ b/internal/model/audio.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// 音声ファイル情報
+type Audio struct {
+	ID         uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	MimeType   string    `gorm:"type:varchar(100);not null;column:mime_type"`
+	URL        string    `gorm:"type:varchar(1024);not null"`
+	Filename   string    `gorm:"type:varchar(255);not null"`
+	FileSize   int       `gorm:"not null;column:file_size"`
+	DurationMs int       `gorm:"not null;column:duration_ms"`
+	CreatedAt  time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
+}

--- a/internal/model/episode.go
+++ b/internal/model/episode.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// エピソード情報
+type Episode struct {
+	ID           uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	ChannelID    uuid.UUID  `gorm:"type:uuid;not null;column:channel_id"`
+	Title        string     `gorm:"type:varchar(255);not null"`
+	Description  *string    `gorm:"type:text"`
+	ScriptPrompt string     `gorm:"type:text;not null;column:script_prompt"`
+	BgmID        *uuid.UUID `gorm:"type:uuid;column:bgm_id"`
+	FullAudioID  *uuid.UUID `gorm:"type:uuid;column:full_audio_id"`
+	PublishedAt  *time.Time `gorm:"column:published_at"`
+	CreatedAt    time.Time  `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	UpdatedAt    time.Time  `gorm:"not null;default:CURRENT_TIMESTAMP"`
+
+	// リレーション
+	Channel   Channel `gorm:"foreignKey:ChannelID"`
+	Bgm       *Audio  `gorm:"foreignKey:BgmID"`
+	FullAudio *Audio  `gorm:"foreignKey:FullAudioID"`
+}

--- a/internal/repository/episode.go
+++ b/internal/repository/episode.go
@@ -1,0 +1,71 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/siropaca/anycast-backend/internal/apperror"
+	"github.com/siropaca/anycast-backend/internal/logger"
+	"github.com/siropaca/anycast-backend/internal/model"
+)
+
+// エピソードデータへのアクセスインターフェース
+type EpisodeRepository interface {
+	FindByChannelID(ctx context.Context, channelID uuid.UUID, filter EpisodeFilter) ([]model.Episode, int64, error)
+}
+
+// エピソード検索のフィルタ条件
+type EpisodeFilter struct {
+	Status *string // "published" or "draft"
+	Limit  int
+	Offset int
+}
+
+type episodeRepository struct {
+	db *gorm.DB
+}
+
+// EpisodeRepository の実装を返す
+func NewEpisodeRepository(db *gorm.DB) EpisodeRepository {
+	return &episodeRepository{db: db}
+}
+
+// 指定されたチャンネルのエピソード一覧を取得する
+func (r *episodeRepository) FindByChannelID(ctx context.Context, channelID uuid.UUID, filter EpisodeFilter) ([]model.Episode, int64, error) {
+	var episodes []model.Episode
+	var total int64
+
+	tx := r.db.WithContext(ctx).Model(&model.Episode{}).Where("channel_id = ?", channelID)
+
+	// ステータスフィルタ
+	if filter.Status != nil {
+		switch *filter.Status {
+		case "published":
+			tx = tx.Where("published_at IS NOT NULL AND published_at <= ?", time.Now())
+		case "draft":
+			tx = tx.Where("published_at IS NULL")
+		}
+	}
+
+	// 総件数を取得
+	if err := tx.Count(&total).Error; err != nil {
+		logger.FromContext(ctx).Error("failed to count episodes", "error", err, "channel_id", channelID)
+		return nil, 0, apperror.ErrInternal.WithMessage("Failed to count episodes").WithError(err)
+	}
+
+	// ページネーションとリレーションのプリロード
+	if err := tx.
+		Preload("FullAudio").
+		Order("created_at DESC").
+		Limit(filter.Limit).
+		Offset(filter.Offset).
+		Find(&episodes).Error; err != nil {
+		logger.FromContext(ctx).Error("failed to fetch episodes", "error", err, "channel_id", channelID)
+		return nil, 0, apperror.ErrInternal.WithMessage("Failed to fetch episodes").WithError(err)
+	}
+
+	return episodes, total, nil
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -67,6 +67,7 @@ func Setup(container *di.Container, cfg *config.Config) *gin.Engine {
 	// Me（自分のリソース）
 	authenticated.GET("/me", container.AuthHandler.GetMe)
 	authenticated.GET("/me/channels", container.ChannelHandler.ListMyChannels)
+	authenticated.GET("/me/channels/:channelId/episodes", container.EpisodeHandler.ListMyChannelEpisodes)
 
 	// Channels
 	authenticated.GET("/channels/:channelId", container.ChannelHandler.GetChannel)

--- a/internal/service/episode.go
+++ b/internal/service/episode.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+
+	"github.com/siropaca/anycast-backend/internal/apperror"
+	"github.com/siropaca/anycast-backend/internal/dto/response"
+	"github.com/siropaca/anycast-backend/internal/model"
+	"github.com/siropaca/anycast-backend/internal/pkg/uuid"
+	"github.com/siropaca/anycast-backend/internal/repository"
+)
+
+// エピソード関連のビジネスロジックインターフェース
+type EpisodeService interface {
+	ListMyChannelEpisodes(ctx context.Context, userID, channelID string, filter repository.EpisodeFilter) (*response.EpisodeListWithPaginationResponse, error)
+}
+
+type episodeService struct {
+	episodeRepo repository.EpisodeRepository
+	channelRepo repository.ChannelRepository
+}
+
+// EpisodeService の実装を返す
+func NewEpisodeService(
+	episodeRepo repository.EpisodeRepository,
+	channelRepo repository.ChannelRepository,
+) EpisodeService {
+	return &episodeService{
+		episodeRepo: episodeRepo,
+		channelRepo: channelRepo,
+	}
+}
+
+// 自分のチャンネルのエピソード一覧を取得する
+func (s *episodeService) ListMyChannelEpisodes(ctx context.Context, userID, channelID string, filter repository.EpisodeFilter) (*response.EpisodeListWithPaginationResponse, error) {
+	uid, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	cid, err := uuid.Parse(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	// チャンネルの存在確認とオーナーチェック
+	channel, err := s.channelRepo.FindByID(ctx, cid)
+	if err != nil {
+		return nil, err
+	}
+
+	if channel.UserID != uid {
+		return nil, apperror.ErrForbidden.WithMessage("You do not have permission to access this channel")
+	}
+
+	// エピソード一覧を取得
+	episodes, total, err := s.episodeRepo.FindByChannelID(ctx, cid, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.EpisodeListWithPaginationResponse{
+		Data:       toEpisodeResponses(episodes),
+		Pagination: response.PaginationResponse{Total: total, Limit: filter.Limit, Offset: filter.Offset},
+	}, nil
+}
+
+// Episode モデルのスライスをレスポンス DTO のスライスに変換する
+func toEpisodeResponses(episodes []model.Episode) []response.EpisodeResponse {
+	result := make([]response.EpisodeResponse, len(episodes))
+
+	for i, e := range episodes {
+		result[i] = toEpisodeResponse(&e)
+	}
+
+	return result
+}
+
+// Episode モデルをレスポンス DTO に変換する
+func toEpisodeResponse(e *model.Episode) response.EpisodeResponse {
+	resp := response.EpisodeResponse{
+		ID:           e.ID,
+		Title:        e.Title,
+		Description:  e.Description,
+		ScriptPrompt: e.ScriptPrompt,
+		PublishedAt:  e.PublishedAt,
+		CreatedAt:    e.CreatedAt,
+		UpdatedAt:    e.UpdatedAt,
+	}
+
+	if e.FullAudio != nil {
+		resp.FullAudio = &response.AudioResponse{
+			ID:         e.FullAudio.ID,
+			URL:        e.FullAudio.URL,
+			DurationMs: e.FullAudio.DurationMs,
+		}
+	}
+
+	return resp
+}

--- a/internal/service/episode_test.go
+++ b/internal/service/episode_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siropaca/anycast-backend/internal/model"
+)
+
+func TestToEpisodeResponse(t *testing.T) {
+	now := time.Now()
+	episodeID := uuid.New()
+	channelID := uuid.New()
+	audioID := uuid.New()
+	description := "Test Description"
+
+	baseEpisode := &model.Episode{
+		ID:           episodeID,
+		ChannelID:    channelID,
+		Title:        "Test Episode",
+		Description:  &description,
+		ScriptPrompt: "Test Script Prompt",
+		PublishedAt:  &now,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	t.Run("基本的な変換が正しく行われる", func(t *testing.T) {
+		resp := toEpisodeResponse(baseEpisode)
+
+		assert.Equal(t, episodeID, resp.ID)
+		assert.Equal(t, "Test Episode", resp.Title)
+		assert.Equal(t, &description, resp.Description)
+		assert.Equal(t, "Test Script Prompt", resp.ScriptPrompt)
+		assert.NotNil(t, resp.PublishedAt)
+		assert.Equal(t, now, resp.CreatedAt)
+		assert.Equal(t, now, resp.UpdatedAt)
+	})
+
+	t.Run("FullAudio が nil の場合、レスポンスの FullAudio も nil", func(t *testing.T) {
+		episode := *baseEpisode
+		episode.FullAudio = nil
+
+		resp := toEpisodeResponse(&episode)
+
+		assert.Nil(t, resp.FullAudio)
+	})
+
+	t.Run("FullAudio がある場合、正しく変換される", func(t *testing.T) {
+		episode := *baseEpisode
+		episode.FullAudioID = &audioID
+		episode.FullAudio = &model.Audio{
+			ID:         audioID,
+			URL:        "https://example.com/audio.mp3",
+			DurationMs: 180000,
+		}
+
+		resp := toEpisodeResponse(&episode)
+
+		assert.NotNil(t, resp.FullAudio)
+		assert.Equal(t, audioID, resp.FullAudio.ID)
+		assert.Equal(t, "https://example.com/audio.mp3", resp.FullAudio.URL)
+		assert.Equal(t, 180000, resp.FullAudio.DurationMs)
+	})
+
+	t.Run("Description が nil の場合、レスポンスの Description も nil", func(t *testing.T) {
+		episode := *baseEpisode
+		episode.Description = nil
+
+		resp := toEpisodeResponse(&episode)
+
+		assert.Nil(t, resp.Description)
+	})
+
+	t.Run("PublishedAt が nil の場合、レスポンスの PublishedAt も nil", func(t *testing.T) {
+		episode := *baseEpisode
+		episode.PublishedAt = nil
+
+		resp := toEpisodeResponse(&episode)
+
+		assert.Nil(t, resp.PublishedAt)
+	})
+}
+
+func TestToEpisodeResponses(t *testing.T) {
+	now := time.Now()
+	channelID := uuid.New()
+	desc1 := "Description 1"
+	desc2 := "Description 2"
+
+	episodes := []model.Episode{
+		{
+			ID:           uuid.New(),
+			ChannelID:    channelID,
+			Title:        "Episode 1",
+			Description:  &desc1,
+			ScriptPrompt: "Prompt 1",
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		},
+		{
+			ID:           uuid.New(),
+			ChannelID:    channelID,
+			Title:        "Episode 2",
+			Description:  &desc2,
+			ScriptPrompt: "Prompt 2",
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		},
+	}
+
+	t.Run("複数エピソードを正しく変換する", func(t *testing.T) {
+		result := toEpisodeResponses(episodes)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, "Episode 1", result[0].Title)
+		assert.Equal(t, "Episode 2", result[1].Title)
+	})
+
+	t.Run("scriptPrompt が含まれる", func(t *testing.T) {
+		result := toEpisodeResponses(episodes)
+
+		assert.Equal(t, "Prompt 1", result[0].ScriptPrompt)
+		assert.Equal(t, "Prompt 2", result[1].ScriptPrompt)
+	})
+
+	t.Run("空のスライスの場合、空のスライスを返す", func(t *testing.T) {
+		result := toEpisodeResponses([]model.Episode{})
+
+		assert.Len(t, result, 0)
+		assert.NotNil(t, result)
+	})
+}

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -551,6 +551,91 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/channels/{channelId}/episodes": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "自分のチャンネルに紐付くエピソード一覧を取得します（非公開含む）",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "自分のチャンネルのエピソード一覧取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "チャンネル ID",
+                        "name": "channelId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "公開状態でフィルタ（published / draft）",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "取得件数（デフォルト: 20、最大: 100）",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "オフセット（デフォルト: 0）",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.EpisodeListWithPaginationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/voices": {
             "get": {
                 "description": "利用可能なボイスの一覧を取得します",
@@ -813,6 +898,25 @@ const docTemplate = `{
                 }
             }
         },
+        "response.AudioResponse": {
+            "type": "object",
+            "required": [
+                "durationMs",
+                "id",
+                "url"
+            ],
+            "properties": {
+                "durationMs": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "response.AuthDataResponse": {
             "type": "object",
             "required": [
@@ -1010,6 +1114,60 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "response.EpisodeListWithPaginationResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "pagination"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.EpisodeResponse"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/response.PaginationResponse"
+                }
+            }
+        },
+        "response.EpisodeResponse": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "id",
+                "scriptPrompt",
+                "title",
+                "updatedAt"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "fullAudio": {
+                    "$ref": "#/definitions/response.AudioResponse"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "publishedAt": {
+                    "type": "string"
+                },
+                "scriptPrompt": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -545,6 +545,91 @@
                 }
             }
         },
+        "/me/channels/{channelId}/episodes": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "自分のチャンネルに紐付くエピソード一覧を取得します（非公開含む）",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "自分のチャンネルのエピソード一覧取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "チャンネル ID",
+                        "name": "channelId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "公開状態でフィルタ（published / draft）",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "取得件数（デフォルト: 20、最大: 100）",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "オフセット（デフォルト: 0）",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.EpisodeListWithPaginationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/voices": {
             "get": {
                 "description": "利用可能なボイスの一覧を取得します",
@@ -807,6 +892,25 @@
                 }
             }
         },
+        "response.AudioResponse": {
+            "type": "object",
+            "required": [
+                "durationMs",
+                "id",
+                "url"
+            ],
+            "properties": {
+                "durationMs": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "response.AuthDataResponse": {
             "type": "object",
             "required": [
@@ -1004,6 +1108,60 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "response.EpisodeListWithPaginationResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "pagination"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/response.EpisodeResponse"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/response.PaginationResponse"
+                }
+            }
+        },
+        "response.EpisodeResponse": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "id",
+                "scriptPrompt",
+                "title",
+                "updatedAt"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "fullAudio": {
+                    "$ref": "#/definitions/response.AudioResponse"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "publishedAt": {
+                    "type": "string"
+                },
+                "scriptPrompt": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## 概要

自分のチャンネルに紐づくエピソード一覧を取得する API を実装しました。

## 変更内容

- `GET /api/v1/me/channels/:channelId/episodes` エンドポイントを追加
- Episode / Audio モデルを作成
- EpisodeRepository / EpisodeService / EpisodeHandler を実装
- status クエリパラメータによる公開状態フィルタ（published / draft）に対応
- ページネーション（limit / offset）に対応
- ユニットテストを追加
- Swagger ドキュメントを更新
- http ファイルを追加