### PR TITLE
feat: Episode の script_prompt を nullable に変更

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1238,7 +1238,6 @@ POST /channels/:channelId/episodes
 {
   "title": "エピソードタイトル",
   "description": "エピソードの説明",
-  "scriptPrompt": "今回のテーマについて詳しく解説する",
   "artworkImageId": "uuid",
   "bgmAudioId": "uuid"
 }
@@ -1255,7 +1254,6 @@ PATCH /channels/:channelId/episodes/:episodeId
 {
   "title": "新しいタイトル",
   "description": "新しい説明",
-  "scriptPrompt": "今回のテーマについて詳しく解説する",
   "artworkImageId": "uuid",
   "bgmAudioId": "uuid",
   "publishedAt": "2025-01-01T00:00:00Z"
@@ -1263,6 +1261,8 @@ PATCH /channels/:channelId/episodes/:episodeId
 ```
 
 - `publishedAt`: 公開日時を設定（`null` で非公開化）
+
+> **Note:** `scriptPrompt` は台本生成時に自動で保存されます。直接編集する場合は API から設定可能ですが、通常は台本生成 API 経由で更新されます。
 
 ### エピソード削除
 
@@ -1340,7 +1340,11 @@ POST /channels/:channelId/episodes/:episodeId/script/generate
 }
 ```
 
-- `prompt`: テーマやシナリオを入力。URL が含まれていれば RAG で内容を取得して台本生成に利用
+| フィールド | 型 | 必須 | 説明 |
+|------------|-----|:----:|------|
+| prompt | string | ◯ | テーマやシナリオ。URL が含まれていれば RAG で内容を取得して台本生成に利用 |
+
+> **Note:** `prompt` はエピソードの `scriptPrompt` として自動保存されます。
 
 **レスポンス:**
 ```json

--- a/docs/database.md
+++ b/docs/database.md
@@ -347,7 +347,7 @@ OAuth 認証情報を管理する。1 ユーザーに複数の OAuth プロバ�
 | channel_id | UUID | | - | 所属チャンネル |
 | title | VARCHAR(255) | | - | エピソードタイトル |
 | description | TEXT | | - | エピソードの説明（公開情報） |
-| script_prompt | TEXT | | - | エピソード固有の台本生成設定（内部管理用） |
+| script_prompt | TEXT | ◯ | - | エピソード固有の台本生成設定（台本生成時に自動保存、内部管理用） |
 | artwork_id | UUID | ◯ | - | カバー画像（images 参照） |
 | bgm_id | UUID | ◯ | - | BGM（audios 参照） |
 | full_audio_id | UUID | ◯ | - | 結合済み音声（audios 参照） |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -273,7 +273,7 @@ OAuth プロバイダとの連携情報。
 | channelId | UUID | ◯ | 所属する Channel |
 | title | String | ◯ | エピソードタイトル |
 | description | String | | エピソードの説明（公開情報） |
-| scriptPrompt | String | | エピソード固有の台本生成設定（Channel の設定と組み合わせて使用、内部管理用） |
+| scriptPrompt | String | | エピソード固有の台本生成設定（台本生成時に自動保存、内部管理用） |
 | script | ScriptLine[] | | 台本（順序付きの ScriptLine 配列） |
 | bgm | Audio | | BGM 音声ファイル |
 | fullAudio | Audio | | 結合済み音声（全 ScriptLine + BGM） |

--- a/internal/dto/request/episode.go
+++ b/internal/dto/request/episode.go
@@ -10,7 +10,6 @@ type ListMyChannelEpisodesRequest struct {
 type CreateEpisodeRequest struct {
 	Title          string  `json:"title" binding:"required,max=255"`
 	Description    *string `json:"description"`
-	ScriptPrompt   string  `json:"scriptPrompt" binding:"required"`
 	ArtworkImageID *string `json:"artworkImageId" binding:"omitempty,uuid"`
 	BgmAudioID     *string `json:"bgmAudioId" binding:"omitempty,uuid"`
 }

--- a/internal/dto/response/episode.go
+++ b/internal/dto/response/episode.go
@@ -11,7 +11,7 @@ type EpisodeResponse struct {
 	ID           uuid.UUID        `json:"id" validate:"required"`
 	Title        string           `json:"title" validate:"required"`
 	Description  *string          `json:"description"`
-	ScriptPrompt string           `json:"scriptPrompt" validate:"required"`
+	ScriptPrompt *string          `json:"scriptPrompt,omitempty"`
 	Artwork      *ArtworkResponse `json:"artwork"`
 	FullAudio    *AudioResponse   `json:"fullAudio"`
 	PublishedAt  *time.Time       `json:"publishedAt"`

--- a/internal/handler/episode.go
+++ b/internal/handler/episode.go
@@ -115,7 +115,6 @@ func (h *EpisodeHandler) CreateEpisode(c *gin.Context) {
 		channelID,
 		req.Title,
 		req.Description,
-		req.ScriptPrompt,
 		req.ArtworkImageID,
 		req.BgmAudioID,
 	)

--- a/internal/model/episode.go
+++ b/internal/model/episode.go
@@ -12,7 +12,7 @@ type Episode struct {
 	ChannelID    uuid.UUID  `gorm:"type:uuid;not null;column:channel_id"`
 	Title        string     `gorm:"type:varchar(255);not null"`
 	Description  *string    `gorm:"type:text"`
-	ScriptPrompt string     `gorm:"type:text;not null;column:script_prompt"`
+	ScriptPrompt *string    `gorm:"type:text;column:script_prompt"`
 	ArtworkID    *uuid.UUID `gorm:"type:uuid;column:artwork_id"`
 	BgmID        *uuid.UUID `gorm:"type:uuid;column:bgm_id"`
 	FullAudioID  *uuid.UUID `gorm:"type:uuid;column:full_audio_id"`

--- a/internal/service/episode.go
+++ b/internal/service/episode.go
@@ -15,7 +15,7 @@ import (
 // エピソード関連のビジネスロジックインターフェース
 type EpisodeService interface {
 	ListMyChannelEpisodes(ctx context.Context, userID, channelID string, filter repository.EpisodeFilter) (*response.EpisodeListWithPaginationResponse, error)
-	CreateEpisode(ctx context.Context, userID, channelID, title string, description *string, scriptPrompt string, artworkImageID, bgmAudioID *string) (*response.EpisodeResponse, error)
+	CreateEpisode(ctx context.Context, userID, channelID, title string, description, artworkImageID, bgmAudioID *string) (*response.EpisodeResponse, error)
 	UpdateEpisode(ctx context.Context, userID, channelID, episodeID string, req request.UpdateEpisodeRequest) (*response.EpisodeDataResponse, error)
 	DeleteEpisode(ctx context.Context, userID, channelID, episodeID string) error
 }
@@ -71,7 +71,7 @@ func (s *episodeService) ListMyChannelEpisodes(ctx context.Context, userID, chan
 }
 
 // エピソードを作成する
-func (s *episodeService) CreateEpisode(ctx context.Context, userID, channelID, title string, description *string, scriptPrompt string, artworkImageID, bgmAudioID *string) (*response.EpisodeResponse, error) {
+func (s *episodeService) CreateEpisode(ctx context.Context, userID, channelID, title string, description, artworkImageID, bgmAudioID *string) (*response.EpisodeResponse, error) {
 	uid, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, err
@@ -94,10 +94,9 @@ func (s *episodeService) CreateEpisode(ctx context.Context, userID, channelID, t
 
 	// エピソードを作成
 	episode := &model.Episode{
-		ChannelID:    cid,
-		Title:        title,
-		Description:  description,
-		ScriptPrompt: scriptPrompt,
+		ChannelID:   cid,
+		Title:       title,
+		Description: description,
 	}
 
 	// アートワークが指定されている場合
@@ -178,7 +177,7 @@ func (s *episodeService) UpdateEpisode(ctx context.Context, userID, channelID, e
 		episode.Description = req.Description
 	}
 	if req.ScriptPrompt != nil {
-		episode.ScriptPrompt = *req.ScriptPrompt
+		episode.ScriptPrompt = req.ScriptPrompt
 	}
 
 	// アートワークの更新

--- a/internal/service/episode_test.go
+++ b/internal/service/episode_test.go
@@ -16,13 +16,14 @@ func TestToEpisodeResponse(t *testing.T) {
 	channelID := uuid.New()
 	audioID := uuid.New()
 	description := "Test Description"
+	scriptPrompt := "Test Script Prompt"
 
 	baseEpisode := &model.Episode{
 		ID:           episodeID,
 		ChannelID:    channelID,
 		Title:        "Test Episode",
 		Description:  &description,
-		ScriptPrompt: "Test Script Prompt",
+		ScriptPrompt: &scriptPrompt,
 		PublishedAt:  &now,
 		CreatedAt:    now,
 		UpdatedAt:    now,
@@ -34,7 +35,7 @@ func TestToEpisodeResponse(t *testing.T) {
 		assert.Equal(t, episodeID, resp.ID)
 		assert.Equal(t, "Test Episode", resp.Title)
 		assert.Equal(t, &description, resp.Description)
-		assert.Equal(t, "Test Script Prompt", resp.ScriptPrompt)
+		assert.Equal(t, &scriptPrompt, resp.ScriptPrompt)
 		assert.NotNil(t, resp.PublishedAt)
 		assert.Equal(t, now, resp.CreatedAt)
 		assert.Equal(t, now, resp.UpdatedAt)
@@ -90,6 +91,8 @@ func TestToEpisodeResponses(t *testing.T) {
 	channelID := uuid.New()
 	desc1 := "Description 1"
 	desc2 := "Description 2"
+	prompt1 := "Prompt 1"
+	prompt2 := "Prompt 2"
 
 	episodes := []model.Episode{
 		{
@@ -97,7 +100,7 @@ func TestToEpisodeResponses(t *testing.T) {
 			ChannelID:    channelID,
 			Title:        "Episode 1",
 			Description:  &desc1,
-			ScriptPrompt: "Prompt 1",
+			ScriptPrompt: &prompt1,
 			CreatedAt:    now,
 			UpdatedAt:    now,
 		},
@@ -106,7 +109,7 @@ func TestToEpisodeResponses(t *testing.T) {
 			ChannelID:    channelID,
 			Title:        "Episode 2",
 			Description:  &desc2,
-			ScriptPrompt: "Prompt 2",
+			ScriptPrompt: &prompt2,
 			CreatedAt:    now,
 			UpdatedAt:    now,
 		},
@@ -123,8 +126,8 @@ func TestToEpisodeResponses(t *testing.T) {
 	t.Run("scriptPrompt が含まれる", func(t *testing.T) {
 		result := toEpisodeResponses(episodes)
 
-		assert.Equal(t, "Prompt 1", result[0].ScriptPrompt)
-		assert.Equal(t, "Prompt 2", result[1].ScriptPrompt)
+		assert.Equal(t, &prompt1, result[0].ScriptPrompt)
+		assert.Equal(t, &prompt2, result[1].ScriptPrompt)
 	})
 
 	t.Run("空のスライスの場合、空のスライスを返す", func(t *testing.T) {

--- a/migrations/000018_make_episode_script_prompt_nullable.down.sql
+++ b/migrations/000018_make_episode_script_prompt_nullable.down.sql
@@ -1,0 +1,5 @@
+-- episodes テーブルの script_prompt を NOT NULL に戻す
+-- 既存の NULL データを空文字に変換
+UPDATE episodes SET script_prompt = '' WHERE script_prompt IS NULL;
+
+ALTER TABLE episodes ALTER COLUMN script_prompt SET NOT NULL;

--- a/migrations/000018_make_episode_script_prompt_nullable.up.sql
+++ b/migrations/000018_make_episode_script_prompt_nullable.up.sql
@@ -1,0 +1,2 @@
+-- episodes テーブルの script_prompt を NULL 許可に変更
+ALTER TABLE episodes ALTER COLUMN script_prompt DROP NOT NULL;


### PR DESCRIPTION
## 概要

Episode の `script_prompt` フィールドを nullable に変更し、API の `scriptPrompt` パラメータをオプショナルにする。

## 変更内容

- Episode の `script_prompt` を NULL 許可に変更（マイグレーション追加）
- API の `scriptPrompt` パラメータを作成リクエストから削除
- モデル・DTO・サービス・ハンドラを `*string` 型に対応
- ドキュメント（specification.md, api.md, database.md）を更新
- テストを修正

## 備考

台本生成 API（`POST /channels/:channelId/episodes/:episodeId/script/generate`）は未実装のため、`prompt` を `script_prompt` に保存する処理は、当該 API 実装時に追加する。