### PR TITLE
feat: 自分のチャンネル/エピソード取得 API を追加

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,9 @@
 | GET | `/api/v1/me` | [現在のユーザー取得](#現在のユーザー取得) | ✅ |
 | PATCH | `/api/v1/me` | [ユーザー情報更新](#ユーザー情報更新) | |
 | GET | `/api/v1/me/channels` | [自分のチャンネル一覧](#自分のチャンネル一覧取得) | ✅ |
+| GET | `/api/v1/me/channels/:channelId` | [自分のチャンネル取得](#自分のチャンネル取得) | ✅ |
 | GET | `/api/v1/me/channels/:channelId/episodes` | [自分のチャンネルのエピソード一覧](#自分のチャンネルのエピソード一覧取得) | ✅ |
+| GET | `/api/v1/me/channels/:channelId/episodes/:episodeId` | [自分のチャンネルのエピソード取得](#自分のチャンネルのエピソード取得) | ✅ |
 | **[Episodes](#episodes)** | - | - | - |
 | GET | `/api/v1/channels/:channelId/episodes` | [エピソード一覧取得](#エピソード一覧取得公開用) | |
 | GET | `/api/v1/channels/:channelId/episodes/:episodeId` | [エピソード取得](#エピソード取得) | |
@@ -1073,6 +1075,69 @@ GET /me/channels
 }
 ```
 
+### 自分のチャンネル取得
+
+```
+GET /me/channels/:channelId
+```
+
+自分のチャンネルを取得（非公開含む）。編集画面での使用を想定。
+
+**パスパラメータ:**
+
+| パラメータ | 型 | 説明 |
+|------------|-----|------|
+| channelId | uuid | チャンネル ID |
+
+**レスポンス:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "チャンネル名",
+    "description": "説明",
+    "scriptPrompt": "明るく楽しい雰囲気で...",
+    "category": { "id": "uuid", "slug": "technology", "name": "テクノロジー" },
+    "artwork": { "id": "uuid", "url": "..." },
+    "characters": [
+      {
+        "id": "uuid",
+        "name": "太郎",
+        "persona": "明るい性格",
+        "voice": {
+          "id": "uuid",
+          "name": "ja-JP-Wavenet-C",
+          "gender": "male"
+        }
+      }
+    ],
+    "publishedAt": "2025-01-01T00:00:00Z",
+    "createdAt": "2025-01-01T00:00:00Z",
+    "updatedAt": "2025-01-01T00:00:00Z"
+  }
+}
+```
+
+**エラー（403 Forbidden）:**
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "このチャンネルへのアクセス権限がありません"
+  }
+}
+```
+
+**エラー（404 Not Found）:**
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "チャンネルが見つかりません"
+  }
+}
+```
+
 ### 自分のチャンネルのエピソード一覧取得
 
 ```
@@ -1134,6 +1199,58 @@ GET /me/channels/:channelId/episodes
   "error": {
     "code": "NOT_FOUND",
     "message": "チャンネルが見つかりません"
+  }
+}
+```
+
+### 自分のチャンネルのエピソード取得
+
+```
+GET /me/channels/:channelId/episodes/:episodeId
+```
+
+自分のチャンネルに紐付くエピソードを取得（非公開含む）。編集画面での使用を想定。
+
+**パスパラメータ:**
+
+| パラメータ | 型 | 説明 |
+|------------|-----|------|
+| channelId | uuid | チャンネル ID |
+| episodeId | uuid | エピソード ID |
+
+**レスポンス:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "title": "エピソードタイトル",
+    "description": "エピソードの説明",
+    "scriptPrompt": "今回のテーマについて詳しく解説する",
+    "artwork": { "id": "uuid", "url": "..." },
+    "fullAudio": { "id": "uuid", "url": "...", "durationMs": 180000 },
+    "publishedAt": "2025-01-01T00:00:00Z",
+    "createdAt": "2025-01-01T00:00:00Z",
+    "updatedAt": "2025-01-01T00:00:00Z"
+  }
+}
+```
+
+**エラー（403 Forbidden）:**
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "このチャンネルへのアクセス権限がありません"
+  }
+}
+```
+
+**エラー（404 Not Found）:**
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "エピソードが見つかりません"
   }
 }
 ```

--- a/http/channels.http
+++ b/http/channels.http
@@ -15,6 +15,10 @@ Authorization: Bearer {{token}}
 GET {{baseUrl}}/me/channels?status=draft
 Authorization: Bearer {{token}}
 
+### 自分のチャンネル取得
+GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE
+Authorization: Bearer {{token}}
+
 ### チャンネル取得
 GET {{baseUrl}}/channels/YOUR_CHANNEL_ID_HERE
 Authorization: Bearer {{token}}

--- a/http/episodes.http
+++ b/http/episodes.http
@@ -19,6 +19,10 @@ Authorization: Bearer {{token}}
 GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE/episodes?limit=10&offset=0
 Authorization: Bearer {{token}}
 
+### 自分のチャンネルのエピソード取得
+GET {{baseUrl}}/me/channels/YOUR_CHANNEL_ID_HERE/episodes/YOUR_EPISODE_ID_HERE
+Authorization: Bearer {{token}}
+
 ### エピソード作成
 POST {{baseUrl}}/channels/YOUR_CHANNEL_ID_HERE/episodes
 Content-Type: application/json

--- a/internal/handler/channel.go
+++ b/internal/handler/channel.go
@@ -65,6 +65,43 @@ func (h *ChannelHandler) ListMyChannels(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// GetMyChannel godoc
+// @Summary 自分のチャンネル取得
+// @Description 認証ユーザーの所有するチャンネルを取得します（非公開含む）
+// @Tags me
+// @Accept json
+// @Produce json
+// @Param channelId path string true "チャンネル ID"
+// @Success 200 {object} response.ChannelDataResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 403 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
+// @Security BearerAuth
+// @Router /me/channels/{channelId} [get]
+func (h *ChannelHandler) GetMyChannel(c *gin.Context) {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		Error(c, apperror.ErrUnauthorized)
+		return
+	}
+
+	channelID := c.Param("channelId")
+	if channelID == "" {
+		Error(c, apperror.ErrValidation.WithMessage("channelId is required"))
+		return
+	}
+
+	result, err := h.channelService.GetMyChannel(c.Request.Context(), userID, channelID)
+	if err != nil {
+		Error(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
 // CreateChannel godoc
 // @Summary チャンネル作成
 // @Description 新しいチャンネルを作成します

--- a/internal/handler/episode.go
+++ b/internal/handler/episode.go
@@ -74,6 +74,50 @@ func (h *EpisodeHandler) ListMyChannelEpisodes(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// GetMyChannelEpisode godoc
+// @Summary 自分のチャンネルのエピソード取得
+// @Description 自分のチャンネルに紐付くエピソードを取得します（非公開含む）
+// @Tags me
+// @Accept json
+// @Produce json
+// @Param channelId path string true "チャンネル ID"
+// @Param episodeId path string true "エピソード ID"
+// @Success 200 {object} response.EpisodeDataResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 403 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
+// @Security BearerAuth
+// @Router /me/channels/{channelId}/episodes/{episodeId} [get]
+func (h *EpisodeHandler) GetMyChannelEpisode(c *gin.Context) {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		Error(c, apperror.ErrUnauthorized)
+		return
+	}
+
+	channelID := c.Param("channelId")
+	if channelID == "" {
+		Error(c, apperror.ErrValidation.WithMessage("channelId is required"))
+		return
+	}
+
+	episodeID := c.Param("episodeId")
+	if episodeID == "" {
+		Error(c, apperror.ErrValidation.WithMessage("episodeId is required"))
+		return
+	}
+
+	result, err := h.episodeService.GetMyChannelEpisode(c.Request.Context(), userID, channelID, episodeID)
+	if err != nil {
+		Error(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
 // CreateEpisode godoc
 // @Summary エピソード作成
 // @Description 指定したチャンネルにエピソードを作成します

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -67,7 +67,9 @@ func Setup(container *di.Container, cfg *config.Config) *gin.Engine {
 	// Me（自分のリソース）
 	authenticated.GET("/me", container.AuthHandler.GetMe)
 	authenticated.GET("/me/channels", container.ChannelHandler.ListMyChannels)
+	authenticated.GET("/me/channels/:channelId", container.ChannelHandler.GetMyChannel)
 	authenticated.GET("/me/channels/:channelId/episodes", container.EpisodeHandler.ListMyChannelEpisodes)
+	authenticated.GET("/me/channels/:channelId/episodes/:episodeId", container.EpisodeHandler.GetMyChannelEpisode)
 
 	// Channels
 	authenticated.GET("/channels/:channelId", container.ChannelHandler.GetChannel)

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -991,6 +991,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/channels/{channelId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "認証ユーザーの所有するチャンネルを取得します（非公開含む）",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "自分のチャンネル取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "チャンネル ID",
+                        "name": "channelId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ChannelDataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/me/channels/{channelId}/episodes": {
             "get": {
                 "security": [
@@ -1041,6 +1108,80 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.EpisodeListWithPaginationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/me/channels/{channelId}/episodes/{episodeId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "自分のチャンネルに紐付くエピソードを取得します（非公開含む）",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "自分のチャンネルのエピソード取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "チャンネル ID",
+                        "name": "channelId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "エピソード ID",
+                        "name": "episodeId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.EpisodeDataResponse"
                         }
                     },
                     "400": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -985,6 +985,73 @@
                 }
             }
         },
+        "/me/channels/{channelId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "認証ユーザーの所有するチャンネルを取得します（非公開含む）",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "自分のチャンネル取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "チャンネル ID",
+                        "name": "channelId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ChannelDataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/me/channels/{channelId}/episodes": {
             "get": {
                 "security": [
@@ -1035,6 +1102,80 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.EpisodeListWithPaginationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/me/channels/{channelId}/episodes/{episodeId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "自分のチャンネルに紐付くエピソードを取得します（非公開含む）",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "自分のチャンネルのエピソード取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "チャンネル ID",
+                        "name": "channelId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "エピソード ID",
+                        "name": "episodeId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.EpisodeDataResponse"
                         }
                     },
                     "400": {


### PR DESCRIPTION
## 概要

自分のチャンネルおよびエピソードを個別に取得する API を追加します。

## 変更内容

- `GET /api/v1/me/channels/:channelId` - 自分のチャンネル取得
- `GET /api/v1/me/channels/:channelId/episodes/:episodeId` - 自分のチャンネルのエピソード取得
- ハンドラーテスト追加
- Swagger ドキュメント更新
- API ドキュメント更新
- HTTP テストファイル更新
