### PR TITLE
fix: 完了遷移前にキャンセルチェックを追加

### DIFF
--- a/internal/service/audio_job.go
+++ b/internal/service/audio_job.go
@@ -576,9 +576,11 @@ func (s *audioJobService) downloadFromStorage(ctx context.Context, path string) 
 }
 
 // updateProgress はジョブの進捗を更新し WebSocket で通知する
+//
+// 進捗のみを更新し、ステータスなど他のフィールドは変更しない
 func (s *audioJobService) updateProgress(ctx context.Context, job *model.AudioJob, progress int, message string) {
 	job.Progress = progress
-	_ = s.audioJobRepo.Update(ctx, job) //nolint:errcheck // progress update is best effort
+	_ = s.audioJobRepo.UpdateProgress(ctx, job.ID, progress) //nolint:errcheck // progress update is best effort
 	s.notifyProgress(job.ID.String(), job.UserID.String(), progress, message)
 }
 

--- a/internal/service/script_job.go
+++ b/internal/service/script_job.go
@@ -493,9 +493,11 @@ func (s *scriptJobService) buildUserPrompt(user *model.User, channel *model.Chan
 }
 
 // updateProgress はジョブの進捗を更新し WebSocket で通知する
+//
+// 進捗のみを更新し、ステータスなど他のフィールドは変更しない
 func (s *scriptJobService) updateProgress(ctx context.Context, job *model.ScriptJob, progress int, message string) {
 	job.Progress = progress
-	_ = s.scriptJobRepo.Update(ctx, job) //nolint:errcheck // progress update is best effort
+	_ = s.scriptJobRepo.UpdateProgress(ctx, job.ID, progress) //nolint:errcheck // progress update is best effort
 	s.notifyProgress(job.ID.String(), job.UserID.String(), progress, message)
 }
 

--- a/internal/service/script_job_test.go
+++ b/internal/service/script_job_test.go
@@ -66,6 +66,11 @@ func (m *mockScriptJobRepository) Delete(ctx context.Context, id uuid.UUID) erro
 	return args.Error(0)
 }
 
+func (m *mockScriptJobRepository) UpdateProgress(ctx context.Context, id uuid.UUID, progress int) error {
+	args := m.Called(ctx, id, progress)
+	return args.Error(0)
+}
+
 func TestScriptJobStatus(t *testing.T) {
 	t.Run("ScriptJobStatus 定数が正しい", func(t *testing.T) {
 		assert.Equal(t, model.ScriptJobStatus("pending"), model.ScriptJobStatusPending)
@@ -160,6 +165,35 @@ func TestScriptJobService_CancelJob(t *testing.T) {
 		var appErr *apperror.AppError
 		assert.True(t, errors.As(err, &appErr))
 		assert.Equal(t, apperror.CodeForbidden, appErr.Code)
+		mockRepo.AssertExpectations(t)
+	})
+}
+
+func TestScriptJobService_updateProgress(t *testing.T) {
+	jobID := uuid.New()
+	userID := uuid.New()
+	episodeID := uuid.New()
+
+	t.Run("UpdateProgress は進捗のみを更新しステータスを上書きしない", func(t *testing.T) {
+		mockRepo := new(mockScriptJobRepository)
+		job := &model.ScriptJob{
+			ID:        jobID,
+			EpisodeID: episodeID,
+			UserID:    userID,
+			Status:    model.ScriptJobStatusProcessing,
+			Progress:  30,
+		}
+
+		// UpdateProgress が呼ばれることを確認（Update ではなく）
+		mockRepo.On("UpdateProgress", mock.Anything, jobID, 50).Return(nil)
+
+		svc := &scriptJobService{scriptJobRepo: mockRepo}
+		svc.updateProgress(context.Background(), job, 50, "処理中...")
+
+		// job.Progress がメモリ上で更新されていることを確認
+		assert.Equal(t, 50, job.Progress)
+		// Status は変更されていないことを確認
+		assert.Equal(t, model.ScriptJobStatusProcessing, job.Status)
 		mockRepo.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## 概要

`processing → canceling → canceled` の状態遷移中に `executeJobInternal` が完了してしまうと、`canceling` 状態が `completed` で上書きされ、`canceled` WebSocket 通知が送信されない問題を修正します。

## 問題

1. キャンセル API を呼び出すと、ジョブステータスが `canceling` に変わる
2. WebSocket で `script_canceling` / `audio_canceling` が送信される（正常）
3. `executeJobInternal` が完了すると、`canceling` が `completed` で上書きされる
4. 結果として `script_canceled` / `audio_canceled` 通知が送信されない

## 修正内容

完了状態への遷移前に `checkCanceled` を呼び出すことで、キャンセル要求があった場合は正しく `canceled` 状態に遷移し、WebSocket で `audio_canceled` / `script_canceled` 通知を送信するようにしました。

## テスト方法

1. ジョブを作成して `processing` 状態にする
2. キャンセル API を呼び出す
3. WebSocket で `script_canceling` / `audio_canceling` → `script_canceled` / `audio_canceled` の順に通知が届くことを確認