### PR TITLE
feat: エピソードへのリアクション・コメント機能を追加

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -110,6 +110,12 @@
 | POST | `/api/v1/episodes/:episodeId/follow` | フォロー登録 | Owner | | [詳細](./engagement.md#フォロー登録) |
 | DELETE | `/api/v1/episodes/:episodeId/follow` | フォロー解除 | Owner | | [詳細](./engagement.md#フォロー解除) |
 | GET | `/api/v1/me/follows` | フォロー中のエピソード一覧 | Owner | | [詳細](./engagement.md#フォロー中のエピソード一覧) |
+| **Comments（コメント）** | - | - | - | - | [engagement.md](./engagement.md#commentsコメント) |
+| POST | `/api/v1/episodes/:episodeId/comments` | コメント投稿 | Owner | | [詳細](./engagement.md#コメント投稿) |
+| GET | `/api/v1/episodes/:episodeId/comments` | コメント一覧取得 | Public | | [詳細](./engagement.md#コメント一覧取得) |
+| PATCH | `/api/v1/comments/:commentId` | コメント編集 | Owner/Admin | | [詳細](./engagement.md#コメント編集) |
+| DELETE | `/api/v1/comments/:commentId` | コメント削除 | Owner/Admin | | [詳細](./engagement.md#コメント削除) |
+| GET | `/api/v1/me/comments` | 自分のコメント一覧 | Owner | | [詳細](./engagement.md#自分のコメント一覧) |
 | **Voices（ボイス）** | - | - | - | - | [master.md](./master.md) |
 | GET | `/api/v1/voices` | ボイス一覧取得 | Public | ✅ | [詳細](./master.md#ボイス一覧取得) |
 | GET | `/api/v1/voices/:voiceId` | ボイス取得 | Public | ✅ | [詳細](./master.md#ボイス取得) |

--- a/docs/api/engagement.md
+++ b/docs/api/engagement.md
@@ -533,3 +533,222 @@ GET /me/follows
   }
 }
 ```
+
+---
+
+# Comments（コメント）
+
+エピソードへのコメント機能。
+
+## コメント投稿
+
+```
+POST /episodes/:episodeId/comments
+```
+
+**リクエスト:**
+```json
+{
+  "content": "とても参考になりました！"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|------------|-----|:----:|------|
+| content | string | ◯ | コメント本文（1〜1000文字） |
+
+**レスポンス（201 Created）:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "user": {
+      "id": "uuid",
+      "username": "user_name",
+      "displayName": "ユーザー名",
+      "avatar": { "id": "uuid", "url": "..." }
+    },
+    "episodeId": "uuid",
+    "content": "とても参考になりました！",
+    "createdAt": "2025-01-01T00:00:00Z",
+    "updatedAt": "2025-01-01T00:00:00Z"
+  }
+}
+```
+
+**エラー（400 Bad Request）:**
+```json
+{
+  "error": {
+    "code": "INVALID_CONTENT_LENGTH",
+    "message": "コメントは1〜1000文字で入力してください"
+  }
+}
+```
+
+---
+
+## コメント一覧取得
+
+```
+GET /episodes/:episodeId/comments
+```
+
+**クエリパラメータ:**
+
+| パラメータ | 型 | デフォルト | 説明 |
+|------------|-----|------------|------|
+| limit | int | 20 | 取得件数（最大 100） |
+| offset | int | 0 | オフセット |
+
+**レスポンス:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "user": {
+        "id": "uuid",
+        "username": "user_name",
+        "displayName": "ユーザー名",
+        "avatar": { "id": "uuid", "url": "..." }
+      },
+      "content": "とても参考になりました！",
+      "createdAt": "2025-01-01T00:00:00Z",
+      "updatedAt": "2025-01-01T00:00:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 100,
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+※ 削除されたコメント（deleted_at が設定されているもの）は表示されない
+
+---
+
+## コメント編集
+
+```
+PATCH /comments/:commentId
+```
+
+コメント投稿者本人または Admin のみ編集可能。
+
+**リクエスト:**
+```json
+{
+  "content": "修正しました。とても参考になりました！"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|------------|-----|:----:|------|
+| content | string | ◯ | コメント本文（1〜1000文字） |
+
+**レスポンス（200 OK）:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "user": {
+      "id": "uuid",
+      "username": "user_name",
+      "displayName": "ユーザー名",
+      "avatar": { "id": "uuid", "url": "..." }
+    },
+    "episodeId": "uuid",
+    "content": "修正しました。とても参考になりました！",
+    "createdAt": "2025-01-01T00:00:00Z",
+    "updatedAt": "2025-01-01T00:00:01Z"
+  }
+}
+```
+
+**エラー（403 Forbidden）:**
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "このコメントを編集する権限がありません"
+  }
+}
+```
+
+---
+
+## コメント削除
+
+```
+DELETE /comments/:commentId
+```
+
+コメント投稿者本人または Admin のみ削除可能。論理削除。
+
+**レスポンス（204 No Content）:**
+レスポンスボディなし
+
+**エラー（403 Forbidden）:**
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "このコメントを削除する権限がありません"
+  }
+}
+```
+
+**エラー（404 Not Found）:**
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "コメントが見つかりません"
+  }
+}
+```
+
+---
+
+## 自分のコメント一覧
+
+```
+GET /me/comments
+```
+
+**クエリパラメータ:**
+
+| パラメータ | 型 | デフォルト | 説明 |
+|------------|-----|------------|------|
+| limit | int | 20 | 取得件数（最大 100） |
+| offset | int | 0 | オフセット |
+
+**レスポンス:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "episode": {
+        "id": "uuid",
+        "title": "エピソードタイトル",
+        "channel": {
+          "id": "uuid",
+          "name": "チャンネル名"
+        }
+      },
+      "content": "とても参考になりました！",
+      "createdAt": "2025-01-01T00:00:00Z",
+      "updatedAt": "2025-01-01T00:00:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 100,
+    "limit": 20,
+    "offset": 0
+  }
+}
+```

--- a/docs/specs/database.md
+++ b/docs/specs/database.md
@@ -13,6 +13,7 @@ erDiagram
     users ||--o{ bookmarks : has
     users ||--o{ playback_histories : has
     users ||--o{ follows : has
+    users ||--o{ comments : has
     users ||--o{ audio_jobs : has
     users ||--o| images : avatar
     categories ||--o{ channels : has
@@ -29,6 +30,7 @@ erDiagram
     episodes ||--o{ bookmarks : has
     episodes ||--o{ playback_histories : has
     episodes ||--o{ follows : has
+    episodes ||--o{ comments : has
     episodes ||--o{ audio_jobs : has
     episodes ||--o| images : artwork
     episodes ||--o| bgms : user_bgm
@@ -69,6 +71,16 @@ erDiagram
         uuid user_id FK
         uuid episode_id FK
         timestamp created_at
+    }
+
+    comments {
+        uuid id PK
+        uuid user_id FK
+        uuid episode_id FK
+        text content
+        timestamp deleted_at
+        timestamp created_at
+        timestamp updated_at
     }
 
     audio_jobs {
@@ -589,6 +601,37 @@ OAuth 認証情報を管理する。1 ユーザーに複数の OAuth プロバ�
 
 **制約:**
 - 自分が所有するチャンネルのエピソードはフォロー不可（アプリケーション層で検証）
+
+---
+
+#### comments
+
+エピソードへのコメントを管理する。
+
+| カラム名 | 型 | NULLABLE | デフォルト | 説明 |
+|----------|-----|:--------:|------------|------|
+| id | UUID | | gen_random_uuid() | 主キー |
+| user_id | UUID | | - | コメント投稿者（users 参照） |
+| episode_id | UUID | | - | エピソード（episodes 参照） |
+| content | TEXT | | - | コメント本文（1〜1000文字） |
+| deleted_at | TIMESTAMP | ◯ | - | 削除日時（NULL = 有効） |
+| created_at | TIMESTAMP | | CURRENT_TIMESTAMP | 投稿日時 |
+| updated_at | TIMESTAMP | | CURRENT_TIMESTAMP | 更新日時 |
+
+**インデックス:**
+- PRIMARY KEY (id)
+- INDEX (user_id)
+- INDEX (episode_id)
+- INDEX (created_at DESC)
+- INDEX (deleted_at)
+
+**外部キー:**
+- user_id → users(id) ON DELETE CASCADE
+- episode_id → episodes(id) ON DELETE CASCADE
+
+**制約:**
+- content は 1〜1000 文字（CHECK 制約）
+- 公開されているエピソードのみコメント可能（アプリケーション層で検証）
 
 ---
 

--- a/docs/specs/domain-model.md
+++ b/docs/specs/domain-model.md
@@ -82,6 +82,7 @@ AI 専用のポッドキャストを作成・配信できるプラットフォ�
 │  Bookmark        : User ─── Episode                                         │
 │  PlaybackHistory : User ─── Episode + 再生状態                              │
 │  Follow          : User ─── Episode（他ユーザーのエピソードのみ）            │
+│  Comment         : User ─── Episode + コメント内容                          │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -112,7 +113,7 @@ AI 専用のポッドキャストを作成・配信できるプラットフォ�
 | 種別 | 名前 | 説明 |
 |------|------|------|
 | エンティティ | User, Channel, Character, Episode, ScriptLine | 一意の識別子を持ち、ライフサイクルを通じて追跡される |
-| エンティティ | Reaction, Bookmark, PlaybackHistory, Follow | ユーザーとエピソードの関連を表す |
+| エンティティ | Reaction, Bookmark, PlaybackHistory, Follow, Comment | ユーザーとエピソードの関連を表す |
 | エンティティ | Voice, Category | システム管理のマスタデータ |
 | エンティティ | Audio, Image | メディアファイル（外部ストレージへの参照） |
 | 値オブジェクト | Email, Username, OAuthProvider, Gender, MimeType | ドメイン固有のルール・制約を持つ値 |
@@ -517,6 +518,26 @@ emotion は TTS 生成時に text の先頭にカッコで付けて表現する�
 - **レジューム再生**: 途中から再生を再開
 - **視聴完了トラッキング**: 最後まで聴いたエピソードの管理
 - **視聴履歴表示**: 最近聴いたエピソードの一覧
+
+### Comment（コメント）
+
+ユーザーがエピソードに対して投稿したコメントを記録する。
+
+| 属性 | 型 | 必須 | 説明 |
+|------|-----|:----:|------|
+| id | UUID | ◯ | 識別子 |
+| userId | UUID | ◯ | コメント投稿者 |
+| episodeId | UUID | ◯ | 対象エピソード |
+| content | String | ◯ | コメント本文（1〜1000文字） |
+| deletedAt | DateTime | | 削除日時（NULL = 有効） |
+| createdAt | DateTime | ◯ | 投稿日時 |
+| updatedAt | DateTime | ◯ | 更新日時 |
+
+#### 制約
+
+- 公開されているエピソードのみコメント可能
+- コメント編集・削除は投稿者本人または Admin のみ
+- 削除されたコメントは一覧に表示されない（論理削除）
 
 ---
 

--- a/migrations/000001_create_tables.down.sql
+++ b/migrations/000001_create_tables.down.sql
@@ -1,5 +1,6 @@
 -- テーブルを依存関係の逆順で削除
 
+DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS follows;
 DROP TABLE IF EXISTS playback_histories;
 DROP TABLE IF EXISTS bookmarks;

--- a/migrations/000001_create_tables.up.sql
+++ b/migrations/000001_create_tables.up.sql
@@ -352,3 +352,20 @@ CREATE TABLE follows (
 
 CREATE INDEX idx_follows_user_id ON follows (user_id);
 CREATE INDEX idx_follows_episode_id ON follows (episode_id);
+
+-- コメント
+CREATE TABLE comments (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	user_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+	episode_id UUID NOT NULL REFERENCES episodes (id) ON DELETE CASCADE,
+	content TEXT NOT NULL,
+	deleted_at TIMESTAMP,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT chk_comments_content_length CHECK (char_length(content) >= 1 AND char_length(content) <= 1000)
+);
+
+CREATE INDEX idx_comments_user_id ON comments (user_id);
+CREATE INDEX idx_comments_episode_id ON comments (episode_id);
+CREATE INDEX idx_comments_created_at ON comments (created_at DESC);
+CREATE INDEX idx_comments_deleted_at ON comments (deleted_at);

--- a/seeds/004_channels_episodes.sql
+++ b/seeds/004_channels_episodes.sql
@@ -11,7 +11,8 @@ DELETE FROM script_lines WHERE episode_id IN (
 DELETE FROM channel_characters WHERE channel_id IN (
 	SELECT id FROM channels WHERE user_id IN ('8def69af-dae9-4641-a0e5-100107626933', '8eada3a5-f413-4eeb-9cd5-12def60d4596')
 );
--- reactions, bookmarks, follows はテストユーザーのものを削除
+-- reactions, bookmarks, follows, comments はテストユーザーのものを削除
+DELETE FROM comments WHERE user_id IN ('8def69af-dae9-4641-a0e5-100107626933', '8eada3a5-f413-4eeb-9cd5-12def60d4596');
 DELETE FROM reactions WHERE user_id IN ('8def69af-dae9-4641-a0e5-100107626933', '8eada3a5-f413-4eeb-9cd5-12def60d4596');
 DELETE FROM bookmarks WHERE user_id IN ('8def69af-dae9-4641-a0e5-100107626933', '8eada3a5-f413-4eeb-9cd5-12def60d4596');
 DELETE FROM follows WHERE user_id IN ('8def69af-dae9-4641-a0e5-100107626933', '8eada3a5-f413-4eeb-9cd5-12def60d4596');
@@ -138,3 +139,13 @@ INSERT INTO bookmarks (id, user_id, episode_id) VALUES
 INSERT INTO follows (id, user_id, episode_id) VALUES
 	('6869b7ad-1859-4b4f-8898-a3229f7ce27d', '8def69af-dae9-4641-a0e5-100107626933', 'fcb16526-951a-4ff1-a456-ab1dba96f699'),
 	('024c2206-a2ed-465d-b468-43a40b891264', '8def69af-dae9-4641-a0e5-100107626933', '9cde2abb-30e8-447b-bc8b-bb799b0f6f06');
+
+-- test_user が test_user2 のエピソードにコメント
+INSERT INTO comments (id, user_id, episode_id, content) VALUES
+	('a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d', '8def69af-dae9-4641-a0e5-100107626933', 'fcb16526-951a-4ff1-a456-ab1dba96f699', 'とても参考になりました！副業から始めるという考え方が新鮮でした。'),
+	('b2c3d4e5-f6a7-5b6c-9d0e-1f2a3b4c5d6e', '8def69af-dae9-4641-a0e5-100107626933', '9cde2abb-30e8-447b-bc8b-bb799b0f6f06', '資金調達の話、勉強になります。');
+
+-- test_user2 が test_user のエピソードにコメント
+INSERT INTO comments (id, user_id, episode_id, content) VALUES
+	('c3d4e5f6-a7b8-6c7d-0e1f-2a3b4c5d6e7f', '8eada3a5-f413-4eeb-9cd5-12def60d4596', 'eb960304-f86e-4364-be5d-d3d5126c9601', 'AIの未来について、とても興味深い内容でした！'),
+	('d4e5f6a7-b8c9-7d8e-1f2a-3b4c5d6e7f8a', '8eada3a5-f413-4eeb-9cd5-12def60d4596', '67e8e26d-20c8-492a-ac2c-5c79d8050aa3', 'スマートホーム、私も導入を検討してみます。');


### PR DESCRIPTION
## 概要

エピソードに対するユーザーインタラクション機能を拡張します。

## 変更内容

### リアクション機能
- `likes` テーブルを `reactions` テーブルに変更
- `reaction_type` ENUM (`like` / `bad`) を追加
- 同じエピソードには 1 つのリアクションのみ設定可能（排他的）
- POST が upsert 動作（既存リアクションを自動更新）

### コメント機能
- `comments` テーブルを追加
- コメント本文は 1〜1000 文字
- 論理削除対応（`deleted_at`）
- 編集・削除は投稿者本人または Admin のみ

### API
| メソッド | パス | 説明 |
|----------|------|------|
| POST | `/episodes/:episodeId/reactions` | リアクション登録・更新 |
| DELETE | `/episodes/:episodeId/reactions` | リアクション解除 |
| POST | `/episodes/:episodeId/comments` | コメント投稿 |
| GET | `/episodes/:episodeId/comments` | コメント一覧取得 |
| PATCH | `/comments/:commentId` | コメント編集 |
| DELETE | `/comments/:commentId` | コメント削除 |
| GET | `/me/comments` | 自分のコメント一覧 |